### PR TITLE
fix: check-prワークフローに必要な権限を追加

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   check-version-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要
check-prワークフローで発生していた403エラー（Resource not accessible by integration）を修正しました。

## 問題
GitHub ActionsのGITHUB_TOKENにissueとPRへの書き込み権限が付与されていなかったため、以下の操作が失敗していました：
- PRへのコメント投稿
- PRのクローズ

## 解決方法
`check-pr.yml` に `permissions` ブロックを追加：
```yaml
permissions:
  issues: write
  pull-requests: write
```

## 変更内容
- `.github/workflows/check-pr.yml` に permissions を追加

## テスト計画
- [ ] このPRをマージ後、version branchからmainへのPRを作成してワークフローが正常に動作することを確認
- [ ] 非version branchからmainへのPRを作成してワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)