### PR TITLE
fix: wrangler.tomlからassets bindingを削除

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,4 +3,3 @@ compatibility_date = "2024-01-01"
 
 [assets]
 directory = "./dist"
-binding = "ASSETS"


### PR DESCRIPTION
assets-onlyのWorkerではbindingが使えないため削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)