### PR TITLE
fix: GitHub Actionsワークフローの通知を改善

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*🚀 デプロイが成功しました*\n\n*リポジトリ:* ${{ github.repository }}\n*バージョン:* `${{ steps.check_version.outputs.version }}`\n*環境:* Production (Cloudflare Workers)\n*作成者:* ${{ github.actor }}\n\n<https://github.com/${{ github.repository }}/releases/tag/${{ steps.check_version.outputs.version }}|リリースを見る>"
+                    "text": "*🚀 デプロイが成功しました*\n\n*リポジトリ:* ${{ github.repository }}\n*バージョン:* `${{ steps.check_version.outputs.version }}`\n*環境:* Production (Cloudflare Workers)\n*作成者:* ${{ github.actor }}\n\n<https://github.com/${{ github.repository }}/releases/tag/${{ steps.check_version.outputs.version }}|リリースを見る>\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|ワークフローログを見る>"
                   }
                 }
               ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,26 +39,6 @@ jobs:
           COMMIT_MSG=$(git log -1 --pretty=%s)
           echo "message=$COMMIT_MSG" >> $GITHUB_OUTPUT
 
-      - name: Notify Slack on success
-        if: success()
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "text": "✅ テストが成功しました",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*✅ テストが成功しました*\n\n*リポジトリ:* ${{ github.repository }}\n*ブランチ:* `${{ github.ref_name }}`\n*コミット:* ${{ steps.commit.outputs.message }}\n*作成者:* ${{ github.actor }}\n\n<${{ github.event.head_commit.url }}|コミットを見る>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
       - name: Notify Slack on failure
         if: failure()
         uses: slackapi/slack-github-action@v1.27.0


### PR DESCRIPTION
## 概要

Issue #45 で指摘されたGitHub Actionsワークフローの通知を改善しました。

## 変更内容

- **テスト成功時のSlack通知を削除**: `.github/workflows/test.yml`から成功時の通知ステップを削除しました
- **デプロイ成功時の通知にGitHub Actionsリンクを追加**: `.github/workflows/deploy.yml`のデプロイ成功通知にワークフローログへのリンクを追加しました
- **既存の失敗時通知を確認**: テスト失敗時とデプロイ失敗時の通知には既にGitHub Actionsへのリンクが含まれていることを確認しました

## 影響

- テストが成功した場合、Slack通知は送信されなくなります
- テスト失敗、デプロイ成功、デプロイ失敗時には、GitHub Actionsの詳細ログへのリンクを含むSlack通知が送信されます

## テスト

変更内容はワークフロー定義のみのため、実際のワークフロー実行時に動作を確認できます。

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)