### PR TITLE
feat: Fisher-Yates シャッフルアルゴリズムを実装 (Fixes #10)

### DIFF
--- a/src/shared/utils/fisherYatesShuffle.test.ts
+++ b/src/shared/utils/fisherYatesShuffle.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest"
+import { fisherYatesShuffle } from "./fisherYatesShuffle"
+
+describe("fisherYatesShuffle", () => {
+  describe("基本的な機能", () => {
+    it("指定された枚数の配列を返す", () => {
+      const result = fisherYatesShuffle(10)
+      expect(result).toHaveLength(10)
+    })
+
+    it("1から指定された枚数までの数字がすべて含まれる", () => {
+      const count = 10
+      const result = fisherYatesShuffle(count)
+      const sorted = [...result].sort((a, b) => a - b)
+
+      // 1からcountまでの配列と一致するか確認
+      expect(sorted).toEqual(Array.from({ length: count }, (_, i) => i + 1))
+    })
+
+    it("各数字が正確に1回だけ出現する", () => {
+      const result = fisherYatesShuffle(20)
+      const uniqueNumbers = new Set(result)
+
+      expect(uniqueNumbers.size).toBe(result.length)
+    })
+
+    it("1枚のカードの場合は[1]を返す", () => {
+      const result = fisherYatesShuffle(1)
+      expect(result).toEqual([1])
+    })
+  })
+
+  describe("シャッフルのランダム性", () => {
+    it("複数回実行すると異なる結果が生成される（確率的テスト）", () => {
+      const results = new Set<string>()
+      const iterations = 100
+
+      for (let i = 0; i < iterations; i++) {
+        const shuffled = fisherYatesShuffle(10)
+        results.add(JSON.stringify(shuffled))
+      }
+
+      // 100回実行して、少なくとも90種類以上の異なる順列が生成されることを期待
+      // （完全にランダムであれば、ほぼ100種類すべて異なるはず）
+      expect(results.size).toBeGreaterThan(90)
+    })
+
+    it("元の順序[1,2,3,...]と異なる結果が高確率で生成される", () => {
+      const original = Array.from({ length: 10 }, (_, i) => i + 1)
+      let differentCount = 0
+
+      // 50回実行
+      for (let i = 0; i < 50; i++) {
+        const shuffled = fisherYatesShuffle(10)
+        if (JSON.stringify(shuffled) !== JSON.stringify(original)) {
+          differentCount++
+        }
+      }
+
+      // 少なくとも45回以上は元の順序と異なるはず
+      // （元の順序になる確率は 1/10! ≈ 0.0000028%）
+      expect(differentCount).toBeGreaterThan(45)
+    })
+  })
+
+  describe("境界値テスト", () => {
+    it("99枚（最大枚数）で正しく動作する", () => {
+      const result = fisherYatesShuffle(99)
+      expect(result).toHaveLength(99)
+
+      const sorted = [...result].sort((a, b) => a - b)
+      expect(sorted).toEqual(Array.from({ length: 99 }, (_, i) => i + 1))
+    })
+
+    it("2枚の場合、[1,2]または[2,1]のいずれかを返す", () => {
+      const result = fisherYatesShuffle(2)
+      expect(result).toHaveLength(2)
+      expect(result).toSatisfy((arr: number[]) => {
+        return (
+          JSON.stringify(arr) === JSON.stringify([1, 2]) ||
+          JSON.stringify(arr) === JSON.stringify([2, 1])
+        )
+      })
+    })
+  })
+
+  describe("パフォーマンス要件", () => {
+    it("99枚のカードで100ms未満で実行される", () => {
+      const startTime = performance.now()
+      fisherYatesShuffle(99)
+      const endTime = performance.now()
+
+      const executionTime = endTime - startTime
+      expect(executionTime).toBeLessThan(100)
+    })
+
+    it("大量の実行でも安定したパフォーマンス", () => {
+      const iterations = 1000
+      const startTime = performance.now()
+
+      for (let i = 0; i < iterations; i++) {
+        fisherYatesShuffle(99)
+      }
+
+      const endTime = performance.now()
+      const averageTime = (endTime - startTime) / iterations
+
+      // 平均実行時間が1ms未満であることを確認
+      expect(averageTime).toBeLessThan(1)
+    })
+  })
+
+  describe("結果の正当性", () => {
+    it("すべての要素が1以上99以下の整数である", () => {
+      const result = fisherYatesShuffle(99)
+
+      for (const num of result) {
+        expect(num).toBeGreaterThanOrEqual(1)
+        expect(num).toBeLessThanOrEqual(99)
+        expect(Number.isInteger(num)).toBe(true)
+      }
+    })
+
+    it("有効な順列である（重複なし、欠損なし）", () => {
+      const count = 52 // トランプ1デッキ分
+      const result = fisherYatesShuffle(count)
+
+      // 重複チェック
+      const uniqueNumbers = new Set(result)
+      expect(uniqueNumbers.size).toBe(count)
+
+      // 範囲チェック
+      for (const num of result) {
+        expect(num).toBeGreaterThanOrEqual(1)
+        expect(num).toBeLessThanOrEqual(count)
+      }
+
+      // ソートすると[1,2,3,...,count]になるか確認
+      const sorted = [...result].sort((a, b) => a - b)
+      expect(sorted).toEqual(Array.from({ length: count }, (_, i) => i + 1))
+    })
+  })
+})

--- a/src/shared/utils/fisherYatesShuffle.ts
+++ b/src/shared/utils/fisherYatesShuffle.ts
@@ -1,0 +1,39 @@
+/**
+ * Fisher-Yates (Knuth) Shuffle Algorithm
+ *
+ * フィッシャー-イェーツアルゴリズムで公平なシャッフルを実現します。
+ * このアルゴリズムは、すべての順列が等確率で生成されることが数学的に証明されています。
+ *
+ * アルゴリズムの仕組み:
+ * 1. 配列の末尾から開始して、先頭に向かって処理
+ * 2. 各位置で、その位置以下のランダムな位置と要素を交換
+ * 3. これにより、各要素が各位置に配置される確率が 1/n となり、完全に公平
+ *
+ * 計算量: O(n) - 配列を1回走査するだけで完了
+ * 空間計算量: O(1) - 入力配列を直接シャッフル
+ *
+ * @param count - シャッフルするカードの枚数（1以上の整数）
+ * @returns シャッフル後の各位置に配置されるカードの元の位置（1-indexed）
+ *
+ * @example
+ * // 10枚のカードをシャッフル
+ * const shuffled = fisherYatesShuffle(10);
+ * // 結果例: [4, 1, 7, 2, 8, 3, 6, 9, 10, 5]
+ * // 意味: 新しい束の1枚目は元の4枚目、2枚目は元の1枚目、など
+ */
+export function fisherYatesShuffle(count: number): number[] {
+  // 1からcountまでの配列を作成（1-indexed）
+  const array: number[] = Array.from({ length: count }, (_, i) => i + 1)
+
+  // Fisher-Yatesアルゴリズム: 末尾から開始
+  for (let i = array.length - 1; i > 0; i--) {
+    // 0からi（inclusive）の範囲でランダムなインデックスを生成
+    const randomIndex = Math.floor(Math.random() * (i + 1))
+
+    // 現在の要素とランダムな位置の要素を交換
+    // 分割代入（destructuring）を使用してスワップ
+    ;[array[i], array[randomIndex]] = [array[randomIndex], array[i]]
+  }
+
+  return array
+}


### PR DESCRIPTION
## Summary

Issue #10 で要求された Fisher-Yates シャッフルアルゴリズムを実装しました。

## 実装内容

### ✅ 実装したファイル
- `src/shared/utils/fisherYatesShuffle.ts` - メインの実装
- `src/shared/utils/fisherYatesShuffle.test.ts` - テストファイル

### ✅ 主な機能
- **公平なシャッフル**: Fisher-Yates (Knuth) アルゴリズムにより、すべての順列が等確率で生成
- **1-indexed 配列**: 仕様通り、1から始まる位置の配列を返す
- **詳細な JSDoc**: アルゴリズムの仕組みと使用例を含む包括的なドキュメント
- **高パフォーマンス**: O(n) の計算量で、99枚でも100ms未満で実行

### ✅ テストカバレッジ
12の包括的なテストケースを実装:
- **基本的な機能** (4テスト): 配列長、数値の完全性、重複チェックなど
- **シャッフルのランダム性** (2テスト): 複数回実行での異なる結果生成を確認
- **境界値テスト** (2テスト): 1枚、2枚、99枚での動作確認
- **パフォーマンス要件** (2テスト): 99枚で100ms未満、1000回実行での平均1ms未満
- **結果の正当性** (2テスト): 整数チェック、有効な順列チェック

## Test plan

- [x] すべてのテストが成功 (12/12)
- [x] ビルドが成功
- [x] Biome のリンターとフォーマッターのチェックが通過
- [x] パフォーマンス要件を満たす (99枚で100ms未満)
- [x] すべての要件を満たす:
  - [x] 関数が [1,2,...,count] の有効な順列を返す
  - [x] すべての数字が正確に1回出現
  - [x] 99枚のカードで100ms未満の実行時間

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)