### PR TITLE
fix: デプロイワークフローのバージョンパターン認識を改善

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,10 @@ jobs:
           echo "Commit message: $COMMIT_MSG"
 
           # Check if this is a merge commit from a version branch (v*.*.*)
-          if echo "$COMMIT_MSG" | grep -qE "Merge.*v[0-9]+\.[0-9]+\.[0-9]+"; then
+          if echo "$COMMIT_MSG" | grep -qiE "v[0-9]+\.[0-9]+\.[0-9]+"; then
             echo "is_version_merge=true" >> $GITHUB_OUTPUT
             # Extract version from commit message
-            VERSION=$(echo "$COMMIT_MSG" | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+" | head -1)
+            VERSION=$(echo "$COMMIT_MSG" | grep -oiE "v[0-9]+\.[0-9]+\.[0-9]+" | head -1)
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "This is a version branch merge: $VERSION"
           else


### PR DESCRIPTION
## 概要

デプロイワークフローが "V0.0.1 (#79)" のようなコミットメッセージを認識できず、デプロイがスキップされていた問題を修正しました。

## 問題の詳細

現在のワークフローは以下のパターンのみを認識していました:
- `Merge` という文字列を含む
- 小文字の `v` で始まるバージョン番号

しかし、実際のコミットメッセージは `V0.0.1 (#79)` という形式で:
- `Merge` という文字列が含まれていない
- 大文字の `V` で始まっている

## 変更内容

正規表現パターンを以下のように修正:

### Before
```bash
grep -qE "Merge.*v[0-9]+\.[0-9]+\.[0-9]+"
grep -oE "v[0-9]+\.[0-9]+\.[0-9]+"
```

### After
```bash
grep -qiE "v[0-9]+\.[0-9]+\.[0-9]+"
grep -oiE "v[0-9]+\.[0-9]+\.[0-9]+"
```

### 変更ポイント
- `-i` オプションを追加して大文字小文字を区別しないように変更
- `Merge.*` を削除してバージョンパターンのみをチェック

## 動作確認

この変更により、以下のような様々な形式のコミットメッセージでデプロイが実行されるようになります:
- `V0.0.1 (#79)` ✅
- `v0.0.1` ✅
- `Merge branch 'v0.0.1'` ✅
- `Release v1.2.3` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)