### PR TITLE
fix: Google Analytics イベント送信の改善

### DIFF
--- a/src/shared/utils/analytics.ts
+++ b/src/shared/utils/analytics.ts
@@ -59,15 +59,30 @@ export const initializeGA = (): void => {
  * @param title - ページのタイトル
  */
 export const trackPageView = (path: string, title?: string): void => {
-  if (!isGAEnabled() || !window.gtag) {
-    console.log(`[GA] [DEV] Page view: ${path} (not sent)`)
+  if (!isGAEnabled()) {
+    if (import.meta.env.DEV) {
+      console.log(`[GA] [DEV] Page view: ${path} (not sent)`)
+    }
     return
   }
 
-  window.gtag("event", "page_view", {
-    page_path: path,
-    page_title: title || document.title,
-  })
+  // gtag.js がロード中の場合は dataLayer に直接 push
+  if (!window.gtag && window.dataLayer) {
+    window.dataLayer.push({
+      event: "page_view",
+      page_path: path,
+      page_title: title || document.title,
+    })
+    return
+  }
+
+  // gtag.js がロード済みの場合は gtag を使用
+  if (window.gtag) {
+    window.gtag("event", "page_view", {
+      page_path: path,
+      page_title: title || document.title,
+    })
+  }
 }
 
 /**
@@ -76,12 +91,26 @@ export const trackPageView = (path: string, title?: string): void => {
  * @param eventParams - イベントパラメータ
  */
 export const trackEvent = (eventName: string, eventParams?: Record<string, unknown>): void => {
-  if (!isGAEnabled() || !window.gtag) {
-    console.log(`[GA] [DEV] Event: ${eventName} (not sent)`, eventParams)
+  if (!isGAEnabled()) {
+    if (import.meta.env.DEV) {
+      console.log(`[GA] [DEV] Event: ${eventName} (not sent)`, eventParams)
+    }
     return
   }
 
-  window.gtag("event", eventName, eventParams)
+  // gtag.js がロード中の場合は dataLayer に直接 push
+  if (!window.gtag && window.dataLayer) {
+    window.dataLayer.push({
+      event: eventName,
+      ...eventParams,
+    })
+    return
+  }
+
+  // gtag.js がロード済みの場合は gtag を使用
+  if (window.gtag) {
+    window.gtag("event", eventName, eventParams)
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Google Analytics のイベント送信を改善し、gtag.js スクリプトのロード完了前でもイベントが失われないように修正しました。

## 変更内容

### 問題
- `initializeGA()` で gtag.js スクリプトを動的にロード（非同期）
- 初回のページビューやイベントが `window.gtag` が undefined の状態で呼ばれる可能性
- その結果、イベントが Google Analytics に送信されない問題

### 解決策
- `trackPageView()` / `trackEvent()` 関数を改善:
  - gtag.js ロード中は `window.dataLayer` に直接イベントを push
  - スクリプトロード後に自動的に処理される仕組み
  - プロダクション環境では開発モードのログを非表示化

## Test plan

- [x] `npm run format` - コードフォーマット確認
- [x] `npm run lint` - Lint チェック通過
- [x] `npm run test` - 全テスト通過 (145 tests)
- [ ] プロダクション環境で初回ページビューが GA に送信されることを確認
- [ ] コンソールに開発モードのログが表示されないことを確認

## 影響範囲

- `src/shared/utils/analytics.ts` のみ
- 既存の動作は維持しつつ、ロード中のイベント送信を改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)