### PR TITLE
fix: AdBanner コンポーネントのインデントを修正

### DIFF
--- a/src/shared/components/AdBanner.tsx
+++ b/src/shared/components/AdBanner.tsx
@@ -41,7 +41,7 @@ export function AdBanner() {
           data-ad-format="auto"
           data-full-width-responsive="true"
         />
-    )}
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- AdBanner.tsx の閉じ括弧のインデントを Biome のフォーマット規則に従って修正しました
- lint エラーが解消されました

## Test plan

- [x] `npm run lint` が正常に通ることを確認
- [x] `npm run format` でフォーマットが適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)