### PR TITLE
v0.0.12

### DIFF
--- a/src/shared/components/AdBanner.tsx
+++ b/src/shared/components/AdBanner.tsx
@@ -30,7 +30,7 @@ export function AdBanner() {
       <div className="w-full max-w-screen-md">
         <ins
           className="adsbygoogle"
-          style={{ display: "block", height: "90px" }}
+          style={{ display: "block", height: "90px", width: "100%" }}
           data-ad-client={clientId}
           data-ad-slot={slotId}
           data-ad-format="auto"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    host: "0.0.0.0", // WSL/devcontainer環境で外部からアクセス可能にする
+    port: 5173,
+    allowedHosts: ["dev.perfect-shuffle.jonnity.com"],
+  },
   // @ts-expect-error - Vite config types don't include test config, but it works at runtime
   test: {
     environment: "jsdom",


### PR DESCRIPTION
## Summary

- 外側のコンテナに `flex justify-center` を追加して横中央揃えを実現
- 内側のコンテナで `max-w-screen-md` により最大幅を制限
- 開発環境のプレースホルダーを固定高さ `h-[90px]` に変更
- adsense の `<ins>` タグに `height: 90px` を明示的に指定

## 修正内容

### 横中央揃え
- 外側のdivに `flex justify-center` を追加
- 内側に `max-w-screen-md` の制約を持つコンテナを追加

### 高さ指定
- 開発環境: `max-h-[90px] min-h-[90px]` → `h-[90px]` に統一
- 本番環境: adsenseのstyleに `height: "90px"` を追加

## Test plan

- [x] `npm run format` でフォーマットを確認
- [x] `npm run lint` が正常に通ることを確認
- [ ] 開発環境でプレースホルダーが中央に表示されることを確認
- [ ] 本番環境でadsenseが中央に90pxの高さで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)