### PR TITLE
v0.0.12

### DIFF
--- a/src/shared/components/AdBanner.tsx
+++ b/src/shared/components/AdBanner.tsx
@@ -30,7 +30,7 @@ export function AdBanner() {
       <div className="w-full max-w-screen-md">
         <ins
           className="adsbygoogle"
-          style={{ display: "block", height: "90px" }}
+          style={{ display: "block", height: "90px", width: "100%" }}
           data-ad-client={clientId}
           data-ad-slot={slotId}
           data-ad-format="auto"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    host: "0.0.0.0", // WSL/devcontainer環境で外部からアクセス可能にする
+    port: 5173,
+    allowedHosts: ["dev.perfect-shuffle.jonnity.com"],
+  },
   // @ts-expect-error - Vite config types don't include test config, but it works at runtime
   test: {
     environment: "jsdom",


### PR DESCRIPTION
- vite.config.ts に server 設定を追加
  - host: 0.0.0.0 で WSL 外部からアクセス可能に
  - allowedHosts で dev.perfect-shuffle.jonnity.com を許可
- AdBanner の width を 100% に設定して横幅を確保

🤖 Generated with [Claude Code](https://claude.com/claude-code)