### PR TITLE
feat: シャッフル時にカードを3つの束に分けて配置する機能を実装 (#114)

### DIFF
--- a/src/__tests__/integration/userFlows.test.tsx
+++ b/src/__tests__/integration/userFlows.test.tsx
@@ -77,22 +77,19 @@ describe("ユーザーフロー統合テスト", () => {
         expect(screen.getByLabelText("次のカードに進む")).toBeTruthy()
       })
 
-      // 進捗表示が表示されることを確認
-      expect(screen.getByText("1 / 40")).toBeTruthy()
+      // 進捗表示が表示されることを確認（3つの束方式では0から開始）
+      expect(screen.getByText("0 / 40")).toBeTruthy()
 
       // 中断ボタンが表示されることを確認
       expect(screen.getByText("中断")).toBeTruthy()
 
-      // 最初のカード位置が表示されることを確認（モックでは1が返る）
-      expect(screen.getByText("1")).toBeTruthy()
+      // 3つの束のカード位置が表示されることを確認
+      expect(screen.getByText("左")).toBeTruthy()
+      expect(screen.getByText("前")).toBeTruthy()
+      expect(screen.getByText("右")).toBeTruthy()
 
-      // カードを数回めくる（3回）
+      // ラウンドを数回進める（2回）
       const shuffleArea = screen.getByLabelText("次のカードに進む")
-      await user.click(shuffleArea)
-      await waitFor(() => {
-        expect(screen.getByText("2 / 40")).toBeTruthy()
-      })
-
       await user.click(shuffleArea)
       await waitFor(() => {
         expect(screen.getByText("3 / 40")).toBeTruthy()
@@ -100,13 +97,30 @@ describe("ユーザーフロー統合テスト", () => {
 
       await user.click(shuffleArea)
       await waitFor(() => {
-        expect(screen.getByText("4 / 40")).toBeTruthy()
+        expect(screen.getByText("6 / 40")).toBeTruthy()
       })
 
-      // 残りのカードをすべてめくる（40枚目まで）
-      for (let i = 4; i <= 40; i++) {
+      // 残りのラウンドをすべて進める（40枚を3枚ずつ配置するので14ラウンド、残り12ラウンド）
+      // 40枚の場合、40/3=13.33なので、14ラウンド必要（左14枚、前13枚、右13枚）
+      for (let i = 2; i < 14; i++) {
         await user.click(shuffleArea)
       }
+
+      // 最後のラウンド後、進捗が40/40になることを確認
+      await waitFor(() => {
+        expect(screen.getByText("40 / 40")).toBeTruthy()
+      })
+
+      // もう一度クリックして束を重ねる指示画面を表示
+      await user.click(shuffleArea)
+
+      // 束を重ねる指示画面が表示されることを確認
+      await waitFor(() => {
+        expect(screen.getByText("3つの束を重ねましょう")).toBeTruthy()
+      })
+
+      // 束を重ねる指示画面をクリックして完了画面へ
+      await user.click(shuffleArea)
 
       // 完了ページに遷移したことを確認
       await waitFor(
@@ -247,16 +261,16 @@ describe("ユーザーフロー統合テスト", () => {
         expect(screen.getByLabelText("次のカードに進む")).toBeTruthy()
       })
 
-      // 進捗表示が表示されることを確認
-      expect(screen.getByText("1 / 40")).toBeTruthy()
+      // 進捗表示が表示されることを確認（3つの束方式では0から開始）
+      expect(screen.getByText("0 / 40")).toBeTruthy()
 
-      // カードを数回めくる（5回）
+      // ラウンドを数回進める（2回）
       const shuffleArea = screen.getByLabelText("次のカードに進む")
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < 2; i++) {
         await user.click(shuffleArea)
       }
 
-      // 進捗が進んでいることを確認
+      // 進捗が進んでいることを確認（2ラウンドで6枚配置）
       await waitFor(() => {
         expect(screen.getByText("6 / 40")).toBeTruthy()
       })
@@ -349,11 +363,27 @@ describe("ユーザーフロー統合テスト", () => {
         expect(screen.getByLabelText("次のカードに進む")).toBeTruthy()
       })
 
-      // 進捗表示が表示されることを確認
-      expect(screen.getByText("1 / 1")).toBeTruthy()
+      // 進捗表示が表示されることを確認（3つの束方式では0から開始）
+      expect(screen.getByText("0 / 1")).toBeTruthy()
 
-      // 1回クリックして完了
+      // 1回クリックして1枚配置（1枚の場合は左の束のみ）
       const shuffleArea = screen.getByLabelText("次のカードに進む")
+      await user.click(shuffleArea)
+
+      // 進捗が1/1になることを確認
+      await waitFor(() => {
+        expect(screen.getByText("1 / 1")).toBeTruthy()
+      })
+
+      // もう一度クリックして束を重ねる指示画面を表示
+      await user.click(shuffleArea)
+
+      // 束を重ねる指示画面が表示されることを確認
+      await waitFor(() => {
+        expect(screen.getByText("3つの束を重ねましょう")).toBeTruthy()
+      })
+
+      // 束を重ねる指示画面をクリックして完了画面へ
       await user.click(shuffleArea)
 
       // 完了ページに遷移したことを確認
@@ -380,22 +410,22 @@ describe("ユーザーフロー統合テスト", () => {
         expect(screen.getByLabelText("次のカードに進む")).toBeTruthy()
       })
 
-      // Enter キーで次に進む
+      // Enter キーで次に進む（3つの束方式では1回で3枚進む）
       const shuffleArea = screen.getByLabelText("次のカードに進む")
       shuffleArea.focus()
       await user.keyboard("{Enter}")
 
-      // 進捗が進んだことを確認
-      await waitFor(() => {
-        expect(screen.getByText("2 / 60")).toBeTruthy()
-      })
-
-      // Space キーで次に進む
-      await user.keyboard(" ")
-
-      // 進捗が進んだことを確認
+      // 進捗が進んだことを確認（3枚配置）
       await waitFor(() => {
         expect(screen.getByText("3 / 60")).toBeTruthy()
+      })
+
+      // Space キーで次に進む（さらに3枚配置）
+      await user.keyboard(" ")
+
+      // 進捗が進んだことを確認（6枚配置）
+      await waitFor(() => {
+        expect(screen.getByText("6 / 60")).toBeTruthy()
       })
     })
   })

--- a/src/__tests__/integration/userFlows.test.tsx
+++ b/src/__tests__/integration/userFlows.test.tsx
@@ -85,7 +85,7 @@ describe("ユーザーフロー統合テスト", () => {
 
       // 3つの束のカード位置が表示されることを確認
       expect(screen.getByText("左")).toBeTruthy()
-      expect(screen.getByText("前")).toBeTruthy()
+      expect(screen.getByText("真ん中")).toBeTruthy()
       expect(screen.getByText("右")).toBeTruthy()
 
       // ラウンドを数回進める（2回）
@@ -101,7 +101,7 @@ describe("ユーザーフロー統合テスト", () => {
       })
 
       // 残りのラウンドをすべて進める（40枚を3枚ずつ配置するので14ラウンド、残り12ラウンド）
-      // 40枚の場合、40/3=13.33なので、14ラウンド必要（左14枚、前13枚、右13枚）
+      // 40枚の場合、40/3=13.33なので、14ラウンド必要（左14枚、真ん中13枚、右13枚）
       for (let i = 2; i < 14; i++) {
         await user.click(shuffleArea)
       }

--- a/src/features/shuffle/components/StackingInstruction.tsx
+++ b/src/features/shuffle/components/StackingInstruction.tsx
@@ -1,0 +1,57 @@
+/**
+ * 3つの束を重ねる指示を表示するコンポーネント
+ *
+ * すべてのカード配置が完了した後、右・前・左の順に重ねる指示を表示する
+ */
+export function StackingInstruction() {
+  return (
+    <div
+      className="flex w-full flex-col items-center justify-center gap-8 py-8"
+      role="status"
+      aria-live="polite"
+    >
+      {/* タイトル */}
+      <div className="text-center">
+        <h2 className="text-2xl font-bold text-gray-900">3つの束を重ねましょう</h2>
+      </div>
+
+      {/* 重ねる順序の指示 */}
+      <div className="flex w-full max-w-sm flex-col gap-4">
+        <InstructionStep step={1} text="右の束を手に取る" />
+        <InstructionStep step={2} text="前の束を右の束の下に重ねる" />
+        <InstructionStep step={3} text="左の束を一番下に重ねる" />
+      </div>
+
+      {/* 完了説明 */}
+      <div className="text-center text-sm text-gray-600">
+        <p>右の束が一番上に、</p>
+        <p>前の束が真ん中に、</p>
+        <p>左の束が一番下になります</p>
+      </div>
+
+      {/* タップ指示 */}
+      <div className="text-sm text-gray-500" aria-label="タップまたはEnterキーで完了画面に進む">
+        タップで完了
+      </div>
+    </div>
+  )
+}
+
+interface InstructionStepProps {
+  step: number
+  text: string
+}
+
+/**
+ * 1つの指示ステップ
+ */
+function InstructionStep({ step, text }: InstructionStepProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-sm font-bold text-white">
+        {step}
+      </div>
+      <div className="text-base text-gray-700">{text}</div>
+    </div>
+  )
+}

--- a/src/features/shuffle/components/StackingInstruction.tsx
+++ b/src/features/shuffle/components/StackingInstruction.tsx
@@ -1,7 +1,7 @@
 /**
  * 3つの束を重ねる指示を表示するコンポーネント
  *
- * すべてのカード配置が完了した後、右・前・左の順に重ねる指示を表示する
+ * すべてのカード配置が完了した後、右・真ん中・左の順に重ねる指示を表示する
  */
 export function StackingInstruction() {
   return (
@@ -15,18 +15,13 @@ export function StackingInstruction() {
         <h2 className="text-2xl font-bold text-gray-900">3つの束を重ねましょう</h2>
       </div>
 
-      {/* 重ねる順序の指示 */}
-      <div className="flex w-full max-w-sm flex-col gap-4">
-        <InstructionStep step={1} text="右の束を手に取る" />
-        <InstructionStep step={2} text="前の束を右の束の下に重ねる" />
-        <InstructionStep step={3} text="左の束を一番下に重ねる" />
-      </div>
-
-      {/* 完了説明 */}
-      <div className="text-center text-sm text-gray-600">
-        <p>右の束が一番上に、</p>
-        <p>前の束が真ん中に、</p>
-        <p>左の束が一番下になります</p>
+      {/* 重ねる順序を視覚的に表示 */}
+      <div className="flex flex-col items-center gap-3">
+        <PileBox label="右" position="一番上" />
+        <div className="text-2xl text-gray-400">↓</div>
+        <PileBox label="真ん中" position="真ん中" />
+        <div className="text-2xl text-gray-400">↓</div>
+        <PileBox label="左" position="一番下" />
       </div>
 
       {/* タップ指示 */}
@@ -37,21 +32,19 @@ export function StackingInstruction() {
   )
 }
 
-interface InstructionStepProps {
-  step: number
-  text: string
+interface PileBoxProps {
+  label: string
+  position: string
 }
 
 /**
- * 1つの指示ステップ
+ * 1つの束を表示するボックス
  */
-function InstructionStep({ step, text }: InstructionStepProps) {
+function PileBox({ label, position }: PileBoxProps) {
   return (
-    <div className="flex items-center gap-3">
-      <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-sm font-bold text-white">
-        {step}
-      </div>
-      <div className="text-base text-gray-700">{text}</div>
+    <div className="flex w-48 items-center justify-between rounded-lg border-2 border-gray-300 bg-white px-4 py-3 shadow-sm">
+      <div className="text-lg font-bold text-gray-900">{label}の束</div>
+      <div className="text-sm text-gray-500">{position}</div>
     </div>
   )
 }

--- a/src/features/shuffle/components/TripleShuffleDisplay.tsx
+++ b/src/features/shuffle/components/TripleShuffleDisplay.tsx
@@ -1,0 +1,76 @@
+interface TripleShuffleDisplayProps {
+  leftPosition: number
+  centerPosition: number
+  rightPosition: number
+}
+
+/**
+ * 3つの束を表示するシャッフルコンポーネント
+ *
+ * 左・前・右の3つの束に対して、それぞれ「上からn枚目を置いて」と指示を表示する
+ *
+ * @param leftPosition - 左の束に置くカードの位置（0の場合は配置済み）
+ * @param centerPosition - 前の束に置くカードの位置（0の場合は配置済み）
+ * @param rightPosition - 右の束に置くカードの位置（0の場合は配置済み）
+ */
+export function TripleShuffleDisplay({
+  leftPosition,
+  centerPosition,
+  rightPosition,
+}: TripleShuffleDisplayProps) {
+  return (
+    <div
+      className="flex w-full flex-col items-center justify-center gap-8 py-8"
+      role="status"
+      aria-live="polite"
+    >
+      {/* 3つの束を横並びで表示 */}
+      <div className="grid w-full grid-cols-3 gap-4">
+        {/* 左の束 */}
+        <PileDisplay position={leftPosition} label="左" />
+
+        {/* 前の束 */}
+        <PileDisplay position={centerPosition} label="前" />
+
+        {/* 右の束 */}
+        <PileDisplay position={rightPosition} label="右" />
+      </div>
+
+      {/* タップ指示 */}
+      <div className="text-sm text-gray-500" aria-label="タップまたはEnterキーで次のラウンドに進む">
+        タップで次へ
+      </div>
+    </div>
+  )
+}
+
+interface PileDisplayProps {
+  position: number
+  label: string
+}
+
+/**
+ * 1つの束の表示コンポーネント
+ */
+function PileDisplay({ position, label }: PileDisplayProps) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2">
+      {/* 束のラベル */}
+      <div className="text-xs text-gray-500">{label}</div>
+
+      {/* カード位置または完了マーク */}
+      {position > 0 ? (
+        <div
+          className="text-center"
+          aria-label={`${label}の束に上から${position}枚目を置いてください`}
+        >
+          <div className="text-xs text-gray-600">上から</div>
+          <div className="text-4xl font-extrabold text-gray-900">{position}</div>
+          <div className="text-xs font-bold text-gray-700">枚目</div>
+        </div>
+      ) : (
+        <div className="flex h-20 items-center justify-center text-2xl text-gray-400">✓</div>
+      )}
+    </div>
+  )
+}

--- a/src/features/shuffle/components/TripleShuffleDisplay.tsx
+++ b/src/features/shuffle/components/TripleShuffleDisplay.tsx
@@ -7,10 +7,10 @@ interface TripleShuffleDisplayProps {
 /**
  * 3つの束を表示するシャッフルコンポーネント
  *
- * 左・前・右の3つの束に対して、それぞれ「上からn枚目を置いて」と指示を表示する
+ * 左・真ん中・右の3つの束に対して、それぞれ「上からn枚目を置いて」と指示を表示する
  *
  * @param leftPosition - 左の束に置くカードの位置（0の場合は配置済み）
- * @param centerPosition - 前の束に置くカードの位置（0の場合は配置済み）
+ * @param centerPosition - 真ん中の束に置くカードの位置（0の場合は配置済み）
  * @param rightPosition - 右の束に置くカードの位置（0の場合は配置済み）
  */
 export function TripleShuffleDisplay({
@@ -29,8 +29,8 @@ export function TripleShuffleDisplay({
         {/* 左の束 */}
         <PileDisplay position={leftPosition} label="左" />
 
-        {/* 前の束 */}
-        <PileDisplay position={centerPosition} label="前" />
+        {/* 真ん中の束 */}
+        <PileDisplay position={centerPosition} label="真ん中" />
 
         {/* 右の束 */}
         <PileDisplay position={rightPosition} label="右" />

--- a/src/features/shuffle/hooks/useTripleShuffle.test.ts
+++ b/src/features/shuffle/hooks/useTripleShuffle.test.ts
@@ -1,0 +1,117 @@
+import { renderHook } from "@testing-library/react"
+import { act } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useTripleShuffle } from "./useTripleShuffle"
+
+// fisherYatesShuffle のモック
+vi.mock("@/shared/utils/fisherYatesShuffle", () => ({
+  fisherYatesShuffle: (n: number) => {
+    // テスト用に固定順序を返す（1, 2, 3, ..., n）
+    return Array.from({ length: n }, (_, i) => i + 1)
+  },
+}))
+
+describe("useTripleShuffle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("初期状態では3つの束のカード位置が正しく計算される", () => {
+    const { result } = renderHook(() => useTripleShuffle(9))
+
+    // 9枚のカードを3等分: 左3枚、前3枚、右3枚
+    // シャッフル順序: [1,2,3,4,5,6,7,8,9]
+    // 左の束: [1,2,3]、前の束: [4,5,6]、右の束: [7,8,9]
+    // 初回ラウンド: 左1枚目(1)、前4枚目(4)、右7枚目(7)
+    expect(result.current.currentCardPositions.left).toBe(1)
+    expect(result.current.currentCardPositions.center).toBe(4)
+    expect(result.current.currentCardPositions.right).toBe(7)
+    expect(result.current.remainingCards).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expect(result.current.progress).toEqual({ current: 0, total: 9 })
+    expect(result.current.isAllComplete).toBe(false)
+  })
+
+  it("nextRound を呼ぶと3つの束から同時にカードが削除される", () => {
+    const { result } = renderHook(() => useTripleShuffle(9))
+
+    act(() => {
+      result.current.nextRound()
+    })
+
+    // 1, 4, 7 が削除されて [2,3,5,6,8,9] になる
+    expect(result.current.remainingCards).toEqual([2, 3, 5, 6, 8, 9])
+    expect(result.current.progress).toEqual({ current: 3, total: 9 })
+
+    // 次のラウンド: 左2枚目(2)、前4枚目(5)、右6枚目(8)
+    expect(result.current.currentCardPositions.left).toBe(1) // 残りの中で2は1番目
+    expect(result.current.currentCardPositions.center).toBe(3) // 残りの中で5は3番目
+    expect(result.current.currentCardPositions.right).toBe(5) // 残りの中で8は5番目
+  })
+
+  it("すべてのカードを配置すると isAllComplete が true になる", () => {
+    const { result } = renderHook(() => useTripleShuffle(9))
+
+    // 3ラウンド繰り返す
+    act(() => {
+      result.current.nextRound()
+    })
+    act(() => {
+      result.current.nextRound()
+    })
+    act(() => {
+      result.current.nextRound()
+    })
+
+    expect(result.current.remainingCards).toEqual([])
+    expect(result.current.isAllComplete).toBe(true)
+    expect(result.current.progress).toEqual({ current: 9, total: 9 })
+  })
+
+  it("カード数が3で割り切れない場合、余りが左と前の束に振り分けられる", () => {
+    const { result } = renderHook(() => useTripleShuffle(10))
+
+    // 10枚のカードを3等分: 左4枚、前3枚、右3枚
+    // シャッフル順序: [1,2,3,4,5,6,7,8,9,10]
+    // 左の束: [1,2,3,4]、前の束: [5,6,7]、右の束: [8,9,10]
+    // 初回ラウンド: 左1枚目(1)、前5枚目(5)、右8枚目(8)
+    expect(result.current.currentCardPositions.left).toBe(1)
+    expect(result.current.currentCardPositions.center).toBe(5)
+    expect(result.current.currentCardPositions.right).toBe(8)
+  })
+
+  it("reset を呼ぶと初期状態に戻る", () => {
+    const { result } = renderHook(() => useTripleShuffle(9))
+
+    act(() => {
+      result.current.nextRound()
+    })
+
+    expect(result.current.remainingCards).toEqual([2, 3, 5, 6, 8, 9])
+
+    act(() => {
+      result.current.reset()
+    })
+
+    expect(result.current.remainingCards).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expect(result.current.progress).toEqual({ current: 0, total: 9 })
+  })
+
+  it("残りカードが0の場合、nextRoundを呼んでも変化しない", () => {
+    const { result } = renderHook(() => useTripleShuffle(3))
+
+    // 1ラウンドで全て配置
+    act(() => {
+      result.current.nextRound()
+    })
+
+    expect(result.current.isAllComplete).toBe(true)
+
+    // もう一度呼んでも変化しない
+    act(() => {
+      result.current.nextRound()
+    })
+
+    expect(result.current.remainingCards).toEqual([])
+    expect(result.current.isAllComplete).toBe(true)
+  })
+})

--- a/src/features/shuffle/hooks/useTripleShuffle.test.ts
+++ b/src/features/shuffle/hooks/useTripleShuffle.test.ts
@@ -19,10 +19,10 @@ describe("useTripleShuffle", () => {
   it("初期状態では3つの束のカード位置が正しく計算される", () => {
     const { result } = renderHook(() => useTripleShuffle(9))
 
-    // 9枚のカードを3等分: 左3枚、前3枚、右3枚
+    // 9枚のカードを3等分: 左3枚、真ん中3枚、右3枚
     // シャッフル順序: [1,2,3,4,5,6,7,8,9]
-    // 左の束: [1,2,3]、前の束: [4,5,6]、右の束: [7,8,9]
-    // 初回ラウンド: 左1枚目(1)、前4枚目(4)、右7枚目(7)
+    // 左の束: [1,2,3]、真ん中の束: [4,5,6]、右の束: [7,8,9]
+    // 初回ラウンド: 左1枚目(1)、真ん中4枚目(4)、右7枚目(7)
     expect(result.current.currentCardPositions.left).toBe(1)
     expect(result.current.currentCardPositions.center).toBe(4)
     expect(result.current.currentCardPositions.right).toBe(7)
@@ -42,7 +42,7 @@ describe("useTripleShuffle", () => {
     expect(result.current.remainingCards).toEqual([2, 3, 5, 6, 8, 9])
     expect(result.current.progress).toEqual({ current: 3, total: 9 })
 
-    // 次のラウンド: 左2枚目(2)、前4枚目(5)、右6枚目(8)
+    // 次のラウンド: 左2枚目(2)、真ん中4枚目(5)、右6枚目(8)
     expect(result.current.currentCardPositions.left).toBe(1) // 残りの中で2は1番目
     expect(result.current.currentCardPositions.center).toBe(3) // 残りの中で5は3番目
     expect(result.current.currentCardPositions.right).toBe(5) // 残りの中で8は5番目
@@ -67,13 +67,13 @@ describe("useTripleShuffle", () => {
     expect(result.current.progress).toEqual({ current: 9, total: 9 })
   })
 
-  it("カード数が3で割り切れない場合、余りが左と前の束に振り分けられる", () => {
+  it("カード数が3で割り切れない場合、余りが左と真ん中の束に振り分けられる", () => {
     const { result } = renderHook(() => useTripleShuffle(10))
 
-    // 10枚のカードを3等分: 左4枚、前3枚、右3枚
+    // 10枚のカードを3等分: 左4枚、真ん中3枚、右3枚
     // シャッフル順序: [1,2,3,4,5,6,7,8,9,10]
-    // 左の束: [1,2,3,4]、前の束: [5,6,7]、右の束: [8,9,10]
-    // 初回ラウンド: 左1枚目(1)、前5枚目(5)、右8枚目(8)
+    // 左の束: [1,2,3,4]、真ん中の束: [5,6,7]、右の束: [8,9,10]
+    // 初回ラウンド: 左1枚目(1)、真ん中5枚目(5)、右8枚目(8)
     expect(result.current.currentCardPositions.left).toBe(1)
     expect(result.current.currentCardPositions.center).toBe(5)
     expect(result.current.currentCardPositions.right).toBe(8)

--- a/src/features/shuffle/hooks/useTripleShuffle.ts
+++ b/src/features/shuffle/hooks/useTripleShuffle.ts
@@ -32,7 +32,6 @@ export function useTripleShuffle(totalCards: number) {
   const pileSize = Math.floor(totalCards / 3)
   const leftPileSize = pileSize + (totalCards % 3 > 0 ? 1 : 0) // 余りがある場合、左に1枚追加
   const centerPileSize = pileSize + (totalCards % 3 > 1 ? 1 : 0) // 余りが2以上の場合、中央に1枚追加
-  const rightPileSize = pileSize
 
   // シャッフル順序を3つの束に分割
   // 下1/3を左、中1/3を前、上1/3を右

--- a/src/features/shuffle/hooks/useTripleShuffle.ts
+++ b/src/features/shuffle/hooks/useTripleShuffle.ts
@@ -1,0 +1,142 @@
+import { fisherYatesShuffle } from "@/shared/utils/fisherYatesShuffle"
+import { useCallback, useMemo, useState } from "react"
+
+/**
+ * 3つの束（左・前・右）に分けてシャッフルするカスタムフック
+ *
+ * シャッフル順序を3等分し、各束に対して並行してカード配置を指示する
+ * - 下1/3: 左の束
+ * - 中1/3: 前の束
+ * - 上1/3: 右の束
+ *
+ * @param totalCards - シャッフルするカードの総数
+ * @returns シャッフル状態と操作関数
+ */
+export function useTripleShuffle(totalCards: number) {
+  // シャッフル順序を生成（初回のみ実行）
+  const shuffleOrder = useMemo(() => fisherYatesShuffle(totalCards), [totalCards])
+
+  // 元の順序のカード配列を生成（初回のみ実行）
+  const initialCards = useMemo(
+    () => Array.from({ length: totalCards }, (_, i) => i + 1),
+    [totalCards],
+  )
+
+  // 残りのカード配列（まだめくっていないカード）
+  const [remainingCards, setRemainingCards] = useState<number[]>(initialCards)
+
+  // 現在のラウンド（0から開始、3枚ごとに+1）
+  const currentRound = Math.floor((totalCards - remainingCards.length) / 3)
+
+  // 各束のカード数を計算
+  const pileSize = Math.floor(totalCards / 3)
+  const leftPileSize = pileSize + (totalCards % 3 > 0 ? 1 : 0) // 余りがある場合、左に1枚追加
+  const centerPileSize = pileSize + (totalCards % 3 > 1 ? 1 : 0) // 余りが2以上の場合、中央に1枚追加
+  const rightPileSize = pileSize
+
+  // シャッフル順序を3つの束に分割
+  // 下1/3を左、中1/3を前、上1/3を右
+  const leftPile = useMemo(() => shuffleOrder.slice(0, leftPileSize), [shuffleOrder, leftPileSize])
+  const centerPile = useMemo(
+    () => shuffleOrder.slice(leftPileSize, leftPileSize + centerPileSize),
+    [shuffleOrder, leftPileSize, centerPileSize],
+  )
+  const rightPile = useMemo(
+    () => shuffleOrder.slice(leftPileSize + centerPileSize),
+    [shuffleOrder, leftPileSize, centerPileSize],
+  )
+
+  // 現在のラウンドで配置すべきカードの位置を計算
+  const getCurrentCardPositions = useCallback(() => {
+    const positions = {
+      left: 0,
+      center: 0,
+      right: 0,
+    }
+
+    // 各束の現在のインデックス（そのラウンドまでに配置したカード数）
+    if (currentRound < leftPile.length) {
+      const nextCard = leftPile[currentRound]
+      positions.left = remainingCards.indexOf(nextCard) + 1
+    }
+    if (currentRound < centerPile.length) {
+      const nextCard = centerPile[currentRound]
+      positions.center = remainingCards.indexOf(nextCard) + 1
+    }
+    if (currentRound < rightPile.length) {
+      const nextCard = rightPile[currentRound]
+      positions.right = remainingCards.indexOf(nextCard) + 1
+    }
+
+    return positions
+  }, [currentRound, leftPile, centerPile, rightPile, remainingCards])
+
+  // 進捗情報
+  const progress = {
+    current: Math.min(totalCards - remainingCards.length, totalCards),
+    total: totalCards,
+  }
+
+  // 現在のラウンドが完了しているか（3枚すべて配置済みか）
+  const isRoundComplete = (totalCards - remainingCards.length) % 3 === 0
+
+  // すべてのカード配置が完了したか
+  const isAllComplete = remainingCards.length === 0
+
+  /**
+   * 次のカードに進む
+   * 現在のラウンドで配置すべき3枚のカードをまとめて削除する
+   */
+  const nextRound = useCallback(() => {
+    setRemainingCards((prev) => {
+      if (prev.length === 0) {
+        return prev // すでに全てめくり終わっている場合は何もしない
+      }
+
+      // 現在のラウンドで配置する最大3枚のカードを特定
+      const round = Math.floor((totalCards - prev.length) / 3)
+      const cardsToRemove: number[] = []
+
+      // 左の束
+      if (round < leftPile.length) {
+        cardsToRemove.push(leftPile[round])
+      }
+      // 前の束
+      if (round < centerPile.length) {
+        cardsToRemove.push(centerPile[round])
+      }
+      // 右の束
+      if (round < rightPile.length) {
+        cardsToRemove.push(rightPile[round])
+      }
+
+      // 削除するカードをフィルタリング
+      return prev.filter((card) => !cardsToRemove.includes(card))
+    })
+  }, [leftPile, centerPile, rightPile, totalCards])
+
+  /**
+   * シャッフルをリセット
+   * remainingCards を初期状態に戻す
+   */
+  const reset = useCallback(() => {
+    setRemainingCards(initialCards)
+  }, [initialCards])
+
+  return {
+    /** 現在のラウンドで配置すべきカード位置（左・前・右） */
+    currentCardPositions: getCurrentCardPositions(),
+    /** 残りのカード配列 */
+    remainingCards,
+    /** 進捗情報（current: めくった枚数, total: 総枚数） */
+    progress,
+    /** 現在のラウンドが完了しているか */
+    isRoundComplete,
+    /** すべてのカード配置が完了したか */
+    isAllComplete,
+    /** 次のラウンドに進む関数 */
+    nextRound,
+    /** シャッフルをリセットする関数 */
+    reset,
+  }
+}

--- a/src/features/shuffle/hooks/useTripleShuffle.ts
+++ b/src/features/shuffle/hooks/useTripleShuffle.ts
@@ -2,11 +2,11 @@ import { fisherYatesShuffle } from "@/shared/utils/fisherYatesShuffle"
 import { useCallback, useMemo, useState } from "react"
 
 /**
- * 3つの束（左・前・右）に分けてシャッフルするカスタムフック
+ * 3つの束（左・真ん中・右）に分けてシャッフルするカスタムフック
  *
  * シャッフル順序を3等分し、各束に対して並行してカード配置を指示する
  * - 下1/3: 左の束
- * - 中1/3: 前の束
+ * - 中1/3: 真ん中の束
  * - 上1/3: 右の束
  *
  * @param totalCards - シャッフルするカードの総数
@@ -34,7 +34,7 @@ export function useTripleShuffle(totalCards: number) {
   const centerPileSize = pileSize + (totalCards % 3 > 1 ? 1 : 0) // 余りが2以上の場合、中央に1枚追加
 
   // シャッフル順序を3つの束に分割
-  // 下1/3を左、中1/3を前、上1/3を右
+  // 下1/3を左、中1/3を真ん中、上1/3を右
   const leftPile = useMemo(() => shuffleOrder.slice(0, leftPileSize), [shuffleOrder, leftPileSize])
   const centerPile = useMemo(
     () => shuffleOrder.slice(leftPileSize, leftPileSize + centerPileSize),
@@ -100,7 +100,7 @@ export function useTripleShuffle(totalCards: number) {
       if (round < leftPile.length) {
         cardsToRemove.push(leftPile[round])
       }
-      // 前の束
+      // 真ん中の束
       if (round < centerPile.length) {
         cardsToRemove.push(centerPile[round])
       }
@@ -123,7 +123,7 @@ export function useTripleShuffle(totalCards: number) {
   }, [initialCards])
 
   return {
-    /** 現在のラウンドで配置すべきカード位置（左・前・右） */
+    /** 現在のラウンドで配置すべきカード位置（左・真ん中・右） */
     currentCardPositions: getCurrentCardPositions(),
     /** 残りのカード配列 */
     remainingCards,


### PR DESCRIPTION
## 概要

Issue #114 の要件に基づき、シャッフル時にカードを左・前・右の3つの束に分けて配置することで、作業時間を短縮する機能を実装しました。

## 変更内容

### 新規ファイル
- `useTripleShuffle.ts`: 3つの束に対応したシャッフルロジックフック
- `TripleShuffleDisplay.tsx`: 3つの束の配置指示を表示するコンポーネント
- `StackingInstruction.tsx`: 束を重ねる手順を表示するコンポーネント
- `useTripleShuffle.test.ts`: useTripleShuffleフックのテスト

### 修正ファイル
- `ShufflePage.tsx`: useTripleShuffleフックを使用するように変更
- `userFlows.test.tsx`: 3つの束方式に合わせて統合テストを修正

## 機能詳細

### 1. シャッフル順序の3等分
- シャッフル順序を3等分し、以下のように割り当てます：
  - 下1/3: 左の束
  - 中1/3: 前の束
  - 上1/3: 右の束

### 2. ラウンド制による配置
- 各ラウンドで3つの束それぞれに1枚ずつカードを配置
- タップで次のラウンドに進み、3枚ずつ進捗が進みます

### 3. 束を重ねる指示
- すべてのカード配置完了後、束を重ねる手順を表示：
  1. 右の束を手に取る
  2. 前の束を右の束の下に重ねる
  3. 左の束を一番下に重ねる
- これにより、右→前→左の順で重なり、正しいシャッフル順序が実現されます

## テスト

- `useTripleShuffle.test.ts`: フックのロジックをカバーする単体テスト
- 既存の統合テストを3つの束方式に対応するように修正

## 品質チェック

✅ `npm run format`: コードフォーマット完了  
✅ `npm run lint`: Lintチェック完了  
⏳ `npm run test`: テスト実行中

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)